### PR TITLE
When caniuse-db does not have data about the version being queried, assume it has the same capabilities as the highest version that does have data

### DIFF
--- a/lib/preprocessCaniuseData.js
+++ b/lib/preprocessCaniuseData.js
@@ -1,34 +1,67 @@
 const semver = require('semver');
 
+function buildVersion(major, minor, patch) {
+    if (typeof minor === 'undefined') {
+        minor = 0;
+    }
+    if (typeof patch === 'undefined') {
+        patch = 0;
+    }
+    return [major, minor, patch].join('.');
+}
+
+function addZeroesIfMinorOrPatchIsMissing(version) {
+    version = String(version);
+    version += '.0'.repeat(3 - version.split('.').length);
+    return version;
+}
+
 module.exports = function preprocessCaniuseData(stats) {
     const isSupportedByCaniuseIdAndVersion = {};
     const checkSupportedRangeByCaniuseId = {};
     Object.keys(stats).forEach(caniuseId => {
+        let highestVersionSeen;
+        let highestVersionIsSupported;
+
+        function registerHighVersion(version, isSupported) {
+            version = addZeroesIfMinorOrPatchIsMissing(version);
+            if (!highestVersionSeen || semver.gt(version, highestVersionSeen)) {
+                highestVersionSeen = version;
+                highestVersionIsSupported = isSupported;
+            }
+        }
+
         isSupportedByCaniuseIdAndVersion[caniuseId] = {};
         Object.keys(stats[caniuseId]).forEach(version => {
             const isSupported = /^y/.test(stats[caniuseId][version]);
             if (version === 'all') {
                 (checkSupportedRangeByCaniuseId[caniuseId] = checkSupportedRangeByCaniuseId[caniuseId] || []).push(() => isSupported);
             } else if (/^\d+(\.\d+){0,2}$/.test(version)) {
-                // Exact major or major.minor version
+                // Exact major or major.minor or major.minor.patch version
                 isSupportedByCaniuseIdAndVersion[caniuseId][version] = isSupported;
-            } else if (/^\d+(\.\d+){0,2}-\d+(?:\.\d+){0,2}$/.test(version)) {
-                const range = new semver.Range(version.replace(/-/g, ' - '));
-                (checkSupportedRangeByCaniuseId[caniuseId] = checkSupportedRangeByCaniuseId[caniuseId] || []).push((major, minor, patch) => {
-                    if (typeof minor === 'undefined') {
-                        minor = 0;
-                    }
-                    if (typeof patch === 'undefined') {
-                        patch = 0;
-                    }
-                    if (range.test(major + '.' + minor + '.' + patch)) {
-                        return isSupported;
-                    }
-                });
+                registerHighVersion(version, isSupported);
             } else {
-                // Ignore unsupported version specifier such as "TP"
+                const matchRange = version.match(/^(\d+(?:\.\d+){0,2})-(\d+(?:\.\d+){0,2})$/);
+                if (matchRange) {
+                    registerHighVersion(matchRange[2], isSupported);
+                    const range = new semver.Range(matchRange[1] + ' - ' + matchRange[2]);
+                    (checkSupportedRangeByCaniuseId[caniuseId] = checkSupportedRangeByCaniuseId[caniuseId] || []).push((major, minor, patch) => {
+                        if (range.test(buildVersion(major, minor, patch))) {
+                            return isSupported;
+                        }
+                    });
+                } else {
+                    // Ignore unsupported version specifier such as "TP"
+                }
             }
         });
+        if (highestVersionSeen) {
+            (checkSupportedRangeByCaniuseId[caniuseId] = checkSupportedRangeByCaniuseId[caniuseId] || []).push((major, minor, patch) => {
+                if (semver.gt(buildVersion(major, minor, patch), highestVersionSeen)) {
+                    return highestVersionIsSupported;
+                }
+            });
+        }
     });
 
     return function checkSupported(caniuseId, major, minor, patch) {

--- a/test/preprocessCaniuseData.js
+++ b/test/preprocessCaniuseData.js
@@ -57,8 +57,7 @@ describe('preprocessCaniuseData', function () {
     it('should explode version ranges spanning several minor versions', function () {
         expect({ie: { '10.1-10.2': 'y' }}, 'to support', 'ie', 10, 1)
             .and('to support', 'ie', 10, 2)
-            .and('to be undecided about', 'ie', 10, 0)
-            .and('to be undecided about', 'ie', 10, 3);
+            .and('to be undecided about', 'ie', 10, 0);
     });
 
     it('should explode version ranges spanning several major and minor versions', function () {
@@ -69,8 +68,7 @@ describe('preprocessCaniuseData', function () {
             .and('to support', 'ie', 11, 0)
             .and('to support', 'ie', 11, 20)
             .and('to support', 'ie', 12, 0)
-            .and('to support', 'ie', 12, 1)
-            .and('to be undecided about', 'ie', 12, 2);
+            .and('to support', 'ie', 12, 1);
     });
 
     it('should support multiple non-overlapping ranges', function () {
@@ -84,8 +82,49 @@ describe('preprocessCaniuseData', function () {
             .and('to support', 'ie', 11, 0)
             .and('to support', 'ie', 11, 20)
             .and('to support', 'ie', 12, 0)
-            .and('to support', 'ie', 12, 1)
-            .and('to be undecided about', 'ie', 12, 2);
+            .and('to support', 'ie', 12, 1);
+    });
+
+    describe('when there is only data about older versions of the browser being queried', function () {
+        describe('when the highest known version is given as major', function () {
+            it('should assume that the newer version is supported when the highest known version is', function () {
+                expect({ie: { '10': 'y' }}, 'to support', 'ie', 11);
+            });
+
+            it('should assume that the newer version is not supported when the highest known version is not', function () {
+                expect({ie: { '10': 'n' }}, 'not to support', 'ie', 11);
+            });
+        });
+
+        describe('when the highest known version is given as major.minor', function () {
+            it('should assume that the newer version is supported when the highest known version is', function () {
+                expect({ie: { '10.5': 'y' }}, 'to support', 'ie', 11);
+            });
+
+            it('should assume that the newer version is not supported when the highest known version is not', function () {
+                expect({ie: { '10.5': 'n' }}, 'not to support', 'ie', 11);
+            });
+        });
+
+        describe('when the highest known version is given as major.minor.patch', function () {
+            it('should assume that the newer version is supported when the highest known version is', function () {
+                expect({ie: { '10.5.8': 'y' }}, 'to support', 'ie', 11);
+            });
+
+            it('should assume that the newer version is not supported when the highest known version is not', function () {
+                expect({ie: { '10.5.8': 'n' }}, 'not to support', 'ie', 11);
+            });
+        });
+
+        describe('when the highest known version is given as a range', function () {
+            it('should assume that the newer version is supported when the highest known version is', function () {
+                expect({ie: { '10.2-10.4': 'y' }}, 'to support', 'ie', 11);
+            });
+
+            it('should assume that the newer version is not supported when the highest known version is not', function () {
+                expect({ie: { '10.2-10.4': 'n' }}, 'not to support', 'ie', 11);
+            });
+        });
     });
 
     describe('when there is no data about the browser being queried', function () {


### PR DESCRIPTION
I just [upgraded](https://github.com/Munter/express-legacy-csp/commit/4d061ef8d0b7aa851f729531b76e9cf3575b3959) to the latest version of caniuse-db, which, among other things, adds [the fact that Opera 45 supports both CSP1 and 2](https://github.com/Fyrd/caniuse/commit/c1c45eaaec91af103e66a14b2933f58af8c96eab#diff-cf79ddaa167a4d928c7296c8f88a4f9bR220).

Before that update we would return "undecided" for that particular version of Opera and thus keep the original CSP. In such a case it'd seem reasonable to just assume that it has the same capabilities as the highest known one.