### PR TITLE
Assume that lower versions are unsupported

### DIFF
--- a/lib/preprocessCaniuseData.js
+++ b/lib/preprocessCaniuseData.js
@@ -22,12 +22,16 @@ module.exports = function preprocessCaniuseData(stats) {
     Object.keys(stats).forEach(caniuseId => {
         let highestVersionSeen;
         let highestVersionIsSupported;
+        let lowestVersionSeen;
 
-        function registerHighVersion(version, isSupported) {
+        function registerVersion(version, isSupported) {
             version = addZeroesIfMinorOrPatchIsMissing(version);
             if (!highestVersionSeen || semver.gt(version, highestVersionSeen)) {
                 highestVersionSeen = version;
                 highestVersionIsSupported = isSupported;
+            }
+            if (!lowestVersionSeen || semver.lt(version, lowestVersionSeen)) {
+                lowestVersionSeen = version;
             }
         }
 
@@ -39,11 +43,11 @@ module.exports = function preprocessCaniuseData(stats) {
             } else if (/^\d+(\.\d+){0,2}$/.test(version)) {
                 // Exact major or major.minor or major.minor.patch version
                 isSupportedByCaniuseIdAndVersion[caniuseId][version] = isSupported;
-                registerHighVersion(version, isSupported);
+                registerVersion(version, isSupported);
             } else {
                 const matchRange = version.match(/^(\d+(?:\.\d+){0,2})-(\d+(?:\.\d+){0,2})$/);
                 if (matchRange) {
-                    registerHighVersion(matchRange[2], isSupported);
+                    registerVersion(matchRange[2], isSupported);
                     const range = new semver.Range(matchRange[1] + ' - ' + matchRange[2]);
                     (checkSupportedRangeByCaniuseId[caniuseId] = checkSupportedRangeByCaniuseId[caniuseId] || []).push((major, minor, patch) => {
                         if (range.test(buildVersion(major, minor, patch))) {
@@ -59,6 +63,13 @@ module.exports = function preprocessCaniuseData(stats) {
             (checkSupportedRangeByCaniuseId[caniuseId] = checkSupportedRangeByCaniuseId[caniuseId] || []).push((major, minor, patch) => {
                 if (semver.gt(buildVersion(major, minor, patch), highestVersionSeen)) {
                     return highestVersionIsSupported;
+                }
+            });
+        }
+        if (lowestVersionSeen) {
+            (checkSupportedRangeByCaniuseId[caniuseId] = checkSupportedRangeByCaniuseId[caniuseId] || []).push((major, minor, patch) => {
+                if (semver.lt(buildVersion(major, minor, patch), highestVersionSeen)) {
+                    return false;
                 }
             });
         }

--- a/test/index.js
+++ b/test/index.js
@@ -86,7 +86,6 @@ describe('with multiple directives', function () {
     });
 });
 
-
 describe('with multiple CSP headers', function () {
     // Safari 7
     beforeEach(() => {
@@ -143,6 +142,16 @@ describe('with a "report only" CSP header', function () {
         it('should process the header', function () {
             return expect('script-src somewhere.com/with/a/path', 'to come out as', 'script-src somewhere.com');
         });
+    });
+});
+
+describe('in Chrome 28 on Android 4.4.2', function () {
+    beforeEach(() => {
+        userAgentString = 'Mozilla/5.0 (Linux; Android 4.4.2: sv-se; SAMSUNG SM-C115 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36';
+    });
+
+    it('should strip the Content-Security-Policy header', () => {
+        return expect("script-src somewhere.com/with/a/path 'strict-dynamic'", 'to come out as', undefined);
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -42,14 +42,14 @@ describe('with an empty policy', function () {
     });
 });
 
-describe('with a browser that caniuse-db has data about in a version that is not explicitly mentioned', function () {
+describe('with a browser that caniuse-db has data about in a version that is older than all the explicitly mentioned ones', function () {
     // Chrome 1
     beforeEach(() => {
         userAgentString = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.19 (KHTML, like Gecko) Chrome/1.0.154.36 Safari/525.19';
     });
 
-    it('should leave the CSP string unchanged', function () {
-        return expect('script-src somewhere.com/with/a/path', 'to come out as', 'script-src somewhere.com/with/a/path');
+    it('should assume that CSP is not supported and strip the header', function () {
+        return expect('script-src somewhere.com/with/a/path', 'to come out as', undefined);
     });
 });
 

--- a/test/preprocessCaniuseData.js
+++ b/test/preprocessCaniuseData.js
@@ -42,12 +42,12 @@ describe('preprocessCaniuseData', function () {
 
     it('should let exact major.minor versions through', function () {
         expect({ie: { '11.1': 'y' }}, 'to support', 'ie', 11, 1)
-            .and('to be undecided about', 'ie', 11, 0);
+            .and('not to support', 'ie', 11, 0);
     });
 
     it('should let exact major.minor.patch versions through', function () {
         expect({ie: { '11.1.2': 'y' }}, 'to support', 'ie', 11, 1, 2)
-            .and('to be undecided about', 'ie', 11, 1);
+            .and('not to support', 'ie', 11, 1);
     });
 
     it('should let exact major versions through', function () {
@@ -57,14 +57,14 @@ describe('preprocessCaniuseData', function () {
     it('should explode version ranges spanning several minor versions', function () {
         expect({ie: { '10.1-10.2': 'y' }}, 'to support', 'ie', 10, 1)
             .and('to support', 'ie', 10, 2)
-            .and('to be undecided about', 'ie', 10, 0);
+            .and('not to support', 'ie', 10, 0);
     });
 
     it('should explode version ranges spanning several major and minor versions', function () {
         expect({ie: { '10.3-12.1': 'y' }}, 'to support', 'ie', 10, 3)
             .and('to support', 'ie', 10, 20)
             .and('to support', 'ie', 10, 20, 4)
-            .and('to be undecided about', 'ie', 10, 0)
+            .and('not to support', 'ie', 10, 0)
             .and('to support', 'ie', 11, 0)
             .and('to support', 'ie', 11, 20)
             .and('to support', 'ie', 12, 0)
@@ -76,7 +76,7 @@ describe('preprocessCaniuseData', function () {
             .and('to support', 'ie', 11)
             .and('not to support', 'ie', 10, 0)
             .and('not to support', 'ie', 10, 1)
-            .and('to be undecided about', 'ie', 10, 2)
+            .and('not to support', 'ie', 10, 2)
             .and('to support', 'ie', 10, 3)
             .and('to support', 'ie', 10, 20)
             .and('to support', 'ie', 11, 0)
@@ -123,6 +123,48 @@ describe('preprocessCaniuseData', function () {
 
             it('should assume that the newer version is not supported when the highest known version is not', function () {
                 expect({ie: { '10.2-10.4': 'n' }}, 'not to support', 'ie', 11);
+            });
+        });
+    });
+
+    describe('when there is only data about newer versions of the browser being queried', function () {
+        describe('when the lowest known version is given as major', function () {
+            it('should assume that the older version is not supported when the higher version is not', function () {
+                expect({ie: { '10': 'n' }}, 'not to support', 'ie', 9);
+            });
+
+            it('should assume that the older version is not supported when the higher version is', function () {
+                expect({ie: { '10': 'y' }}, 'not to support', 'ie', 9);
+            });
+        });
+
+        describe('when the highest known version is given as major.minor', function () {
+            it('should assume that the older version is not supported when the higher version is not', function () {
+                expect({ie: { '10.5': 'n' }}, 'not to support', 'ie', 9);
+            });
+
+            it('should assume that the older version is not supported when the higher version is', function () {
+                expect({ie: { '10.5': 'y' }}, 'not to support', 'ie', 9);
+            });
+        });
+
+        describe('when the highest known version is given as major.minor.patch', function () {
+            it('should assume that the older version is not supported when the higher version is not', function () {
+                expect({ie: { '10.5.8': 'n' }}, 'not to support', 'ie', 9);
+            });
+
+            it('should assume that the older version is not supported when the higher version is', function () {
+                expect({ie: { '10.5.8': 'y' }}, 'not to support', 'ie', 9);
+            });
+        });
+
+        describe('when the highest known version is given as a range', function () {
+            it('should assume that the older version is not supported when the higher version is not', function () {
+                expect({ie: { '10.5.2-10.5.8': 'n' }}, 'not to support', 'ie', 9);
+            });
+
+            it('should assume that the older version is not supported when the higher version is', function () {
+                expect({ie: { '10.5.2-10.5.8': 'y' }}, 'not to support', 'ie', 9);
             });
         });
     });


### PR DESCRIPTION
Handle the cases where caniuse-db only has data for version x and above:

```
[features-json]$ grep -r -A10 and_chr contentsecuritypolicy*
contentsecuritypolicy2.json:    "and_chr":{
contentsecuritypolicy2.json-      "56":"y"
contentsecuritypolicy2.json-    },
contentsecuritypolicy2.json-    "and_ff":{
contentsecuritypolicy2.json-      "51":"a #6"
contentsecuritypolicy2.json-    },
contentsecuritypolicy2.json-    "ie_mob":{
contentsecuritypolicy2.json-      "10":"n",
contentsecuritypolicy2.json-      "11":"n"
contentsecuritypolicy2.json-    },
contentsecuritypolicy2.json-    "and_uc":{
--
contentsecuritypolicy.json:    "and_chr":{
contentsecuritypolicy.json-      "56":"y"
contentsecuritypolicy.json-    },
contentsecuritypolicy.json-    "and_ff":{
contentsecuritypolicy.json-      "51":"y"
contentsecuritypolicy.json-    },
contentsecuritypolicy.json-    "ie_mob":{
contentsecuritypolicy.json-      "10":"a #1",
contentsecuritypolicy.json-      "11":"a #1"
contentsecuritypolicy.json-    },
contentsecuritypolicy.json-    "and_uc":{
```