### PR TITLE
Omit directives that cause warnings in CSP1-capable browsers

### DIFF
--- a/lib/downgradeCsp2ToCsp1.js
+++ b/lib/downgradeCsp2ToCsp1.js
@@ -15,7 +15,12 @@ function stripPathsFromSourceExpression(sourceExpression) {
 }
 
 module.exports = function downgradeCsp2ToCsp1(parsedCsp) {
-  return Object.keys(parsedCsp)
+  var filteredCsp = omit(parsedCsp, [
+    'frameAncestors',
+    'manifestSrc',
+    'childSrc'
+  ]);
+  return Object.keys(filteredCsp)
     .filter(directiveName => /Src$/.test(directiveName))
     .reduce((newCsp, directiveName) => {
       const oldValue = parsedCsp[directiveName];
@@ -35,5 +40,5 @@ module.exports = function downgradeCsp2ToCsp1(parsedCsp) {
       );
 
       return newCsp;
-    }, omit(parsedCsp, 'frameAncestors'));
+    }, filteredCsp);
 };

--- a/lib/downgradeCsp2ToCsp1.js
+++ b/lib/downgradeCsp2ToCsp1.js
@@ -1,3 +1,5 @@
+const omit = require('lodash.omit');
+
 const originRegExp = /^(?:([a-z][a-z0-9+.-]+):\/\/)?(\*|(?:\*\.)?[a-z0-9-]+(?:\.[a-z0-9-]+)*)(?::(\d+|\*))?(\/.*)?$/i;
 
 function stripPathsFromSourceExpression(sourceExpression) {
@@ -33,5 +35,5 @@ module.exports = function downgradeCsp2ToCsp1(parsedCsp) {
       );
 
       return newCsp;
-    }, Object.assign({}, parsedCsp));
+    }, omit(parsedCsp, 'frameAncestors'));
 };

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "caniuse-db": "^1.0.30000871",
+    "lodash.omit": "^4.5.0",
     "memoizesync": "^1.1.1",
     "semver": "^5.5.0",
     "useragent": "^2.3.0"

--- a/test/index.js
+++ b/test/index.js
@@ -428,28 +428,26 @@ it('should not crash when the parsed version number is not accepted by the semve
 });
 
 describe('with CSP2 directives', function() {
-  describe('frame-ancestors', function() {
-    describe('in CSP2 capable browsers', function() {
-      it('should keep the directive in Safari 10.1', function() {
-        userAgentString =
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8';
-        return expect(
-          "frame-ancestors 'none'; script-src 'self'",
-          'to be left intact'
-        );
-      });
+  describe('in CSP2 capable browsers', function() {
+    it('should keep the directives in Safari 10.1', function() {
+      userAgentString =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8';
+      return expect(
+        "frame-ancestors 'none'; child-src 'self'; manifest-src 'self'; script-src 'self'",
+        'to be left intact'
+      );
     });
+  });
 
-    describe('in CSP1 capable browsers', function() {
-      it('should drop the directive in Safari 9.1', function() {
-        userAgentString =
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8';
-        return expect(
-          "frame-ancestors 'none'; script-src 'self'",
-          'to come out as',
-          "script-src 'self'"
-        );
-      });
+  describe('in CSP1 capable browsers', function() {
+    it('should drop the directives in Safari 9.1', function() {
+      userAgentString =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8';
+      return expect(
+        "frame-ancestors 'none'; child-src 'self'; manifest-src 'self'; script-src 'self'",
+        'to come out as',
+        "script-src 'self'"
+      );
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -426,3 +426,30 @@ it('should not crash when the parsed version number is not accepted by the semve
     "script-src 'unsafe-inline'"
   );
 });
+
+describe('with CSP2 directives', function() {
+  describe('frame-ancestors', function() {
+    describe('in CSP2 capable browsers', function() {
+      it('should keep the directive in Safari 10.1', function() {
+        userAgentString =
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8';
+        return expect(
+          "frame-ancestors 'none'; script-src 'self'",
+          'to be left intact'
+        );
+      });
+    });
+
+    describe('in CSP1 capable browsers', function() {
+      it('should drop the directive in Safari 9.1', function() {
+        userAgentString =
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8';
+        return expect(
+          "frame-ancestors 'none'; script-src 'self'",
+          'to come out as',
+          "script-src 'self'"
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #9, or is a start, at least. We should probably diff the specs and find all the directives that weren't in CSP1.

Requires some "field work" with actual browsers to be safe. I'm quite sure that especially Chrome started supporting some CSP2/CSP3 directives before their caniuse status actually flipped over.